### PR TITLE
BEAR-14520 update to ruby25

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - log/**/*
     - tmp/**/*
     - db/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,135 @@
+# This file overrides https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+inherit_mode:
+  merge:
+    - Include
+
+AllCops:
+  Include:
+    - Rakefile
+    - Gemfile
+    - config.ru
+    - lib/tasks/*.rake
+  Exclude:
+    - coverage/**/*
+    - vendor/**/*
+    - log/**/*
+    - tmp/**/*
+    - db/**/*
+  TargetRubyVersion: 2.3
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
+  # a Float.
+  Max: 150
+
+Metrics/BlockLength:
+  CountComments: false  # count full line comments?
+  Max: 600
+
+Metrics/PerceivedComplexity:
+  Max: 20
+
+Metrics/CyclomaticComplexity:
+  Max: 20
+
+# Limit lines to 80 characters.
+Layout/LineLength:
+  Enabled: false
+
+# Avoid methods longer than 10 lines of code
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/GlobalVars:
+  AllowedVariables: []
+
+# Favor modifier if/unless usage when you have a single-line body.
+Style/IfUnlessModifier:
+  Enabled: false
+
+# Favor modifier while/until usage when you have a single-line body.
+Style/WhileUntilModifier:
+  Enabled: false
+
+# Preferred collection methods.
+Style/CollectionMethods:
+  Enabled: false
+
+# Don't interpolate global, instance and class variables directly in strings.
+Style/VariableInterpolation:
+  Enabled: false
+
+# Use only ascii symbols in comments.
+Style/AsciiComments:
+  Enabled: false
+
+Style/CaseEquality:
+  Description: 'Avoid explicit use of the case equality operator(===).'
+  Enabled: false
+
+Style/SignalException:
+  Description: 'Checks for proper usage of fail and raise.'
+  Enabled: false
+
+Style/SymbolArray:
+  Description: 'Use %i or %I for arrays of symbols.'
+  Enabled: true
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+
+Style/TrivialAccessors:
+  Enabled: false
+
+# 本来はtrueにしたいが変更範囲が大きすぎるため、一時的にfalse
+Layout/AccessModifierIndentation:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Description: 'Enforces the names of some block params.'
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Naming/FileName:
+  Enabled: false
+
+Layout/ArrayAlignment:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+# 一時的に封鎖
+Naming/AccessorMethodName:
+  Enabled: false
+
+# bear-api-controllerのみ以下を封鎖
+Style/GuardClause:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+    Enabled: false
+
+Style/HashSyntax:
+    Enabled: false
+
+Style/SafeNavigation:
+    Enabled: false
+
+Style/NumericPredicate:
+    Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - log/**/*
     - tmp/**/*
     - db/**/*
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Metrics/ClassLength:
   Enabled: false
 
 Style/GlobalVars:
-  AllowedVariables: []
+  AllowedVariables: [$TESTING]
 
 # Favor modifier if/unless usage when you have a single-line body.
 Style/IfUnlessModifier:

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,2 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/lib/retry-handler.rb
+++ b/lib/retry-handler.rb
@@ -22,8 +22,6 @@ module RetryHandler
     end
   end
 
-  private
-
   def self._retry_handler(max_retry, wait_time, accept_exception, logger, &block)
     retry_cnt = 0
 
@@ -44,6 +42,8 @@ module RetryHandler
       end
     end
   end
+
+  private_class_method :_retry_handler
 end
 
 class Proc

--- a/lib/retry-handler.rb
+++ b/lib/retry-handler.rb
@@ -8,11 +8,11 @@ module RetryHandler
   DEFAULT_WAIT_TIME = 1
   INFINITY_EXECUTE = nil
 
-  def self.retry_handler(options={}, &block)
+  def self.retry_handler(options = {}, &block)
     max = options[:max] || DEFAULT_MAX_RETRY
     wait = options[:wait] || DEFAULT_WAIT_TIME
     timeout = options[:timeout] || INFINITY_EXECUTE
-    exception = options[:accept_exception] || RetryError 
+    exception = options[:accept_exception] || RetryError
     logger = options[:logger] || Logger.new(nil)
 
     _retry_handler(max, wait, exception, logger) do
@@ -23,17 +23,18 @@ module RetryHandler
   end
 
   private
+
   def self._retry_handler(max_retry, wait_time, accept_exception, logger, &block)
-    retry_cnt = 0 
+    retry_cnt = 0
 
     begin
       block.call
-    rescue accept_exception => ex
-      logger.error ex
+    rescue accept_exception => e
+      logger.error e
 
       if retry_cnt >= max_retry
         logger.info "retry over error: #{max_retry}"
-        raise RetryOverError.new, ex
+        raise RetryOverError.new, e
       else
         retry_cnt += 1
         logger.info "retry:#{retry_cnt}"
@@ -46,10 +47,10 @@ module RetryHandler
 end
 
 class Proc
-  def retry(options={})
-    RetryHandler.retry_handler(options){
-      self.call
-    }
+  def retry(options = {})
+    RetryHandler.retry_handler(options) do
+      call
+    end
   end
 end
 
@@ -57,14 +58,13 @@ class Method
   def retry(*args)
     options = args.last.is_a?(::Hash) ? args.pop : {}
     RetryHandler.retry_handler(options) do
-      self.call(*args)
+      call(*args)
     end
   end
 end
 
 module Kernel
-  def retry_handler(options={}, &block)
+  def retry_handler(options = {}, &block)
     block.retry(options) if block_given?
   end
 end
-

--- a/lib/retry-handler/version.rb
+++ b/lib/retry-handler/version.rb
@@ -1,5 +1,5 @@
 module Retry
   module Handler
-    VERSION = '0.4'
+    VERSION = '0.4'.freeze
   end
 end

--- a/lib/retry-handler/version.rb
+++ b/lib/retry-handler/version.rb
@@ -1,5 +1,5 @@
 module Retry
   module Handler
-    VERSION = '0.4'.freeze
+    VERSION = '0.5'.freeze
   end
 end

--- a/retry-handler.gemspec
+++ b/retry-handler.gemspec
@@ -1,17 +1,18 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/retry-handler/version', __FILE__)
+require File.expand_path('lib/retry-handler/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["kimoto"]
-  gem.email         = ["sub+peerler@gmail.com"]
-  gem.description   = %q{Easy retry handling}
-  gem.summary       = %q{Easy retry handling}
-  gem.homepage      = "https://github.com/kimoto/retry-handler"
+  gem.authors       = ['kimoto']
+  gem.email         = ['sub+peerler@gmail.com']
+  gem.description   = 'Easy retry handling'
+  gem.summary       = 'Easy retry handling'
+  gem.homepage      = 'https://github.com/kimoto/retry-handler'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "retry-handler"
-  gem.require_paths = ["lib"]
+  gem.name          = 'retry-handler'
+  gem.require_paths = ['lib']
   gem.version       = Retry::Handler::VERSION
+
+  gem.add_development_dependency 'rubocop', '~> 0.78.0'
 end

--- a/spec/retry-handler_spec.rb
+++ b/spec/retry-handler_spec.rb
@@ -1,7 +1,7 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "retry-handler" do
-  it "should do nothing" do
+describe 'retry-handler' do
+  it 'should do nothing' do
     true.should == true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-$TESTING=true
-$:.push File.join(File.dirname(__FILE__), '..', 'lib')
+$TESTING = true
+$LOAD_PATH.push File.join(File.dirname(__FILE__), '..', 'lib')


### PR DESCRIPTION
## チケット
[\[BEAR-14583\] \[naosukeの20%\] kuma componentsのRuby2.5対応](https://nttcom.atlassian.net/browse/BEAR-14583)

## やったこと
<!---
箇条書きで, 簡単に変更内容を記入してください
-->
- rubocopのTargetRubyVersionを2.5化
- PullReqテンプレートの追加

## see also
[Pull Request時のお約束](https://nttcom.atlassian.net/wiki/spaces/BEAR/pages/389154436/Pull+Request)